### PR TITLE
Add ability to refresh title images

### DIFF
--- a/PinterestSegment/PinterestSegment.swift
+++ b/PinterestSegment/PinterestSegment.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 public struct PinterestSegmentStyle {
-
+    
     public var indicatorColor = UIColor(white: 0.95, alpha: 1)
     public var titleMargin: CGFloat = 16
     public var titlePendingHorizontal: CGFloat = 14
@@ -21,23 +21,28 @@ public struct PinterestSegmentStyle {
     public var normalBorderColor = UIColor.clear
     public var minimumWidth: CGFloat?
     public init() {}
-
+    
 }
 
 @IBDesignable public class PinterestSegment: UIControl {
-
-    public struct TitleElement {
+    
+    public struct TitleElement : Equatable {
         public let title: String
         public let selectedImage: UIImage?
         public let normalImage: UIImage?
-
+        
         public init(title: String, selectedImage: UIImage? = nil, normalImage: UIImage? = nil) {
             self.title = title
             self.selectedImage = selectedImage
             self.normalImage = normalImage
         }
+        
+        public static func == (lhs: TitleElement, rhs: TitleElement) -> Bool
+        {
+            return lhs.title == rhs.title && lhs.selectedImage == rhs.selectedImage && lhs.normalImage == rhs.selectedImage
+        }
     }
-
+    
     public var style: PinterestSegmentStyle {
         didSet {
             reloadLayout()
@@ -49,34 +54,39 @@ public struct PinterestSegmentStyle {
             reloadLayout()
         }
     }
-
+    
     public override var bounds: CGRect {
         didSet {
             guard bounds.size != oldValue.size else { return }
             reloadLayout()
         }
     }
-
-    private var titleElements: [TitleElement] {
+    
+    private var _titleElements: [TitleElement] {
         didSet {
-            reloadData()
-            setSelectIndex(index: 0, animated: true)
+            reloadData(animated: false, sendAction: false)
         }
     }
-
+    public var titleElements: [TitleElement]
+    {
+        get{
+            return _titleElements
+        }
+    }
+    
     @IBInspectable public var titles: [String] {
         get {
             return titleElements.map({ $0.title })
         }
         set {
-            titleElements = newValue.map({ TitleElement(title: $0) })
+            _titleElements = newValue.map({ TitleElement(title: $0) })
         }
     }
-
+    
     public var valueChange: ((Int) -> Void)?
     private var titleLabels: [UILabel] = []
     public private(set) var selectIndex = 0
-
+    
     private let scrollView: UIScrollView = {
         let view = UIScrollView()
         view.showsHorizontalScrollIndicator = false
@@ -89,7 +99,7 @@ public struct PinterestSegmentStyle {
         view.scrollsToTop = false
         return view
     }()
-
+    
     private let selectContent =  UIView()
     private var indicator: UIView = {
         let ind = UIView()
@@ -101,45 +111,45 @@ public struct PinterestSegmentStyle {
         cover.layer.masksToBounds = true
         return cover
     }()
-
+    
     // MARK: - life cycle
     public convenience override init(frame: CGRect) {
         self.init(frame: frame, segmentStyle: PinterestSegmentStyle(), titles: [])
     }
-
+    
     public convenience init(frame: CGRect, titles: [String]) {
         self.init(frame: frame, segmentStyle: PinterestSegmentStyle(), titles: titles)
     }
-
+    
     public init(frame: CGRect, segmentStyle: PinterestSegmentStyle, titles: [String]) {
         self.style = segmentStyle
-        self.titleElements = titles.map({ TitleElement(title: $0)})
+        self._titleElements = titles.map({ TitleElement(title: $0)})
         super.init(frame: frame)
         shareInit()
     }
-
+    
     public convenience init(frame: CGRect, segmentStyle: PinterestSegmentStyle, richTextTitles: [TitleElement]) {
         self.init(frame: frame, segmentStyle: segmentStyle, titles: [])
         setRichTextTitles(richTextTitles)
     }
-
+    
     required public init?(coder aDecoder: NSCoder) {
         self.style = PinterestSegmentStyle()
-        self.titleElements = []
+        self._titleElements = []
         super.init(coder: aDecoder)
         shareInit()
     }
-
+    
     private func shareInit() {
         addSubview(UIView())
         addSubview(scrollView)
         reloadData()
     }
-
+    
     public func setSelectIndex(index: Int, animated: Bool = true) {
         setSelectIndex(index: index, animated: animated, sendAction: true)
     }
-
+    
     // Target action
     @objc private func handleTapGesture(_ gesture: UITapGestureRecognizer) {
         let x = gesture.location(in: self).x + scrollView.contentOffset.x
@@ -149,60 +159,57 @@ public struct PinterestSegmentStyle {
                 break
             }
         }
-
+        
     }
-
+    
     public func setRichTextTitles(_ titles: [TitleElement]) {
-        self.titlePendingHorizontal = self.titlePendingVertical + (titles.first?.selectedImage?.size.width ?? 0)
-        self.titleElements = titles
+        self._titleElements = titles
     }
-
-    private func setSelectIndex(index: Int, animated: Bool, sendAction: Bool) {
-
-        guard index != selectIndex, index >= 0, index < titleLabels.count else { return }
-
+    
+    private func setSelectIndex(index: Int, animated: Bool, sendAction: Bool, forceUpdate : Bool = false) {
+        
+        guard (index != selectIndex || forceUpdate), index >= 0, index < titleLabels.count else { return }
+        
         let currentLabel = titleLabels[index]
         let offSetX = min(max(0, currentLabel.center.x - bounds.width / 2),
                           max(0, scrollView.contentSize.width - bounds.width))
         scrollView.setContentOffset(CGPoint(x: offSetX, y: 0), animated: true)
-
+        
         if animated {
-
+            
             UIView.animate(withDuration: 0.2, animations: {
                 var rect = self.indicator.frame
                 rect.origin.x = currentLabel.frame.origin.x
                 rect.size.width = currentLabel.frame.size.width
                 self.setIndicatorFrame(rect)
             })
-
+            
         } else {
             var rect = indicator.frame
             rect.origin.x = currentLabel.frame.origin.x
             rect.size.width = currentLabel.frame.size.width
             setIndicatorFrame(rect)
         }
-
+        
         selectIndex = index
         if sendAction {
             valueChange?(index)
             sendActions(for: .valueChanged)
         }
     }
-
+    
     private func setIndicatorFrame(_ frame: CGRect) {
         indicator.frame = frame
         selectedLabelsMaskView.frame = frame
-
+        
     }
-
+    
     // Data handler
-
+    
     private func reloadLayout() {
-        let _selectIndex = selectIndex
-        reloadData()
-        setSelectIndex(index: _selectIndex, animated: false, sendAction: false)
+        reloadData(animated: false, sendAction: false)
     }
-
+    
     private func clearData() {
         scrollView.subviews.forEach { $0.removeFromSuperview() }
         selectContent.subviews.forEach { $0.removeFromSuperview() }
@@ -213,10 +220,10 @@ public struct PinterestSegmentStyle {
         }
         titleLabels.removeAll()
     }
-
-    private func reloadData() {
+    
+    private func reloadData(animated: Bool = true, sendAction: Bool = true) {
         clearData()
-
+        
         guard titles.count > 0  else {
             return
         }
@@ -229,29 +236,37 @@ public struct PinterestSegmentStyle {
         }
         let titleY: CGFloat = ( bounds.height - titleH)/2
         let coverH: CGFloat = font.lineHeight + style.titlePendingVertical
-
+        
         selectedLabelsMaskView.backgroundColor = UIColor.black
         scrollView.frame = bounds
         selectContent.frame = bounds
         selectContent.layer.mask = selectedLabelsMaskView.layer
         selectedLabelsMaskView.isUserInteractionEnabled = true
-
+        
         let toToSize: (String) -> CGFloat = { text in
             let result =  (text as NSString).boundingRect(with: CGSize(width: CGFloat.greatestFiniteMagnitude, height: 0.0), options: .usesLineFragmentOrigin, attributes: [.font: font], context: nil).width
-
+            
             if let minWidth = self.style.minimumWidth, result < minWidth {
                 return minWidth
             }
             return result
         }
-
+        
         for (index, item) in titleElements.enumerated() {
-
-            let titleW = toToSize(item.title) + style.titlePendingHorizontal * 2
-
+            
+            var titlePendingHorizontal = style.titlePendingHorizontal
+            
+            //if we are using images, then add a bit of extra horizontal spacing
+            if item.normalImage != nil || item.selectedImage != nil
+            {
+                titlePendingHorizontal = titlePendingHorizontal + font.lineHeight
+            }
+            
+            let titleW = toToSize(item.title) + titlePendingHorizontal * 2
+            
             titleX = (titleLabels.last?.frame.maxX ?? 0 ) + style.titleMargin
             let rect = CGRect(x: titleX, y: titleY, width: titleW, height: titleH)
-
+            
             let backLabel = UILabel(frame: CGRect.zero)
             backLabel.tag = index
             backLabel.text = item.title
@@ -259,17 +274,17 @@ public struct PinterestSegmentStyle {
             backLabel.font = style.titleFont
             backLabel.textAlignment = .center
             backLabel.frame = rect
-
+            
             if style.normalBorderColor != .clear {
                 backLabel.layer.borderColor = UIColor.darkGray.cgColor
                 backLabel.layer.borderWidth = 2
                 backLabel.layer.cornerRadius = backLabel.frame.size.height / 2
             }
-
+            
             if let normalImage = item.normalImage {
                 backLabel.addToLeft(image: normalImage)
             }
-
+            
             let frontLabel = UILabel(frame: CGRect.zero)
             frontLabel.tag = index
             frontLabel.text = item.title
@@ -280,43 +295,44 @@ public struct PinterestSegmentStyle {
             if let selectedImage = item.selectedImage {
                 frontLabel.addToLeft(image: selectedImage)
             }
-
+            
             titleLabels.append(backLabel)
             scrollView.addSubview(backLabel)
             selectContent.addSubview(frontLabel)
-
+            
             if index == titles.count - 1 {
                 scrollView.contentSize.width = rect.maxX + style.titleMargin
                 selectContent.frame.size.width = rect.maxX + style.titleMargin
             }
         }
-
+        
         // Set Cover
         indicator.layer.borderWidth = 2
         indicator.layer.borderColor = style.selectedBorderColor.cgColor
         indicator.backgroundColor = style.indicatorColor
         scrollView.addSubview(indicator)
         scrollView.addSubview(selectContent)
-
+        
         let coverX = titleLabels[0].frame.origin.x
         let coverY = (bounds.size.height - coverH) / 2
         let coverW = titleLabels[0].frame.size.width
-
+        
         let indRect = CGRect(x: coverX, y: coverY, width: coverW, height: coverH)
         setIndicatorFrame(indRect)
-
+        
         indicator.layer.cornerRadius = coverH/2
         selectedLabelsMaskView.layer.cornerRadius = coverH/2
-
+        
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(PinterestSegment.handleTapGesture(_:)))
         addGestureRecognizer(tapGesture)
-        setSelectIndex(index: 0)
-
+        
+        setSelectIndex(index: selectIndex, animated: animated, sendAction: sendAction, forceUpdate: true)
+        
     }
 }
 
 extension PinterestSegment {
-
+    
     public var titleFont: UIFont {
         get {
             return style.titleFont
@@ -325,7 +341,7 @@ extension PinterestSegment {
             style.titleFont = newValue
         }
     }
-
+    
     @IBInspectable public var indicatorColor: UIColor {
         get {
             return style.indicatorColor
@@ -334,7 +350,7 @@ extension PinterestSegment {
             style.indicatorColor = newValue
         }
     }
-
+    
     @IBInspectable public var titleMargin: CGFloat {
         get {
             return style.titleMargin
@@ -343,7 +359,7 @@ extension PinterestSegment {
             style.titleMargin = newValue
         }
     }
-
+    
     @IBInspectable public var titlePendingHorizontal: CGFloat {
         get {
             return style.titlePendingHorizontal
@@ -352,7 +368,7 @@ extension PinterestSegment {
             style.titlePendingHorizontal = newValue
         }
     }
-
+    
     @IBInspectable public var titlePendingVertical: CGFloat {
         get {
             return style.titlePendingVertical
@@ -361,7 +377,7 @@ extension PinterestSegment {
             style.titlePendingVertical = newValue
         }
     }
-
+    
     @IBInspectable public var minimumWidth: CGFloat {
         get {
             return style.minimumWidth ?? 0
@@ -370,7 +386,7 @@ extension PinterestSegment {
             style.minimumWidth = newValue
         }
     }
-
+    
     @IBInspectable public var normalTitleColor: UIColor {
         get {
             return style.normalTitleColor
@@ -379,7 +395,7 @@ extension PinterestSegment {
             style.normalTitleColor = newValue
         }
     }
-
+    
     @IBInspectable public var selectedTitleColor: UIColor {
         get {
             return style.selectedTitleColor
@@ -388,7 +404,7 @@ extension PinterestSegment {
             style.selectedTitleColor = newValue
         }
     }
-
+    
     @IBInspectable public var selectedBorderColor: UIColor {
         get {
             return style.selectedBorderColor
@@ -397,7 +413,7 @@ extension PinterestSegment {
             style.selectedBorderColor = newValue
         }
     }
-
+    
     @IBInspectable public var normalBorderColor: UIColor {
         get {
             return style.selectedBorderColor
@@ -406,7 +422,7 @@ extension PinterestSegment {
             style.selectedBorderColor = newValue
         }
     }
-
+    
 }
 
 extension UILabel {


### PR DESCRIPTION
I have converted my usage of the title images to your new refactor, which I definitely like. However, there are a few functions I had to improve in order to get the functionality I need.
Specifically, I need to be able to update the images on the segment periodically while maintaining state. To do that I needed to:
- make some small changes to the refresh so prevent the segment from reverting back to selected Index = 0
- make the title attributes publicly accessible and added an equatable so I can know when i should update them
- found a bug in adding extra horizontal space when setting images, so cleaned that up 