### PR TITLE
fix vertical alignment of image decorators

### DIFF
--- a/PinterestSegment.podspec
+++ b/PinterestSegment.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "PinterestSegment"
-  s.version      = "1.2.3"
+  s.version      = "1.2.4"
   s.summary      = "PinterestSegment is a animation segment"
   s.license      = { :type => 'MIT License', :file => 'LICENSE' } 
   s.homepage     = "https://github.com/TBXark/PinterestSegment"

--- a/PinterestSegment/PinterestSegment.swift
+++ b/PinterestSegment/PinterestSegment.swift
@@ -428,7 +428,6 @@ extension PinterestSegment {
 extension UILabel {
     @objc public func addToLeft(image: UIImage?) {
         let mutableAttributedString = NSMutableAttributedString()
-        var baseline: CGFloat = 0
         if let image = image {
             let attachment = NSTextAttachment()
             attachment.image = image
@@ -437,13 +436,15 @@ extension UILabel {
                 size.height = bounds.height
                 size.width = size.height * bounds.width / bounds.height
             }
-            baseline = size.height/4
-            attachment.bounds = CGRect(x: 0, y: 0, width: size.width, height: size.height)
+            
+            attachment.bounds = CGRect(x: 0, y: (self.font.capHeight - size.height) / 2, width: image.size.width, height: image.size.height)
+            //baseline = size.height/4
+            //attachment.bounds = CGRect(x: 0, y: 0, width: size.width, height: size.height)
             let attachmentStr = NSAttributedString(attachment: attachment)
             mutableAttributedString.append(attachmentStr)
         }
         if let text = self.text {
-            let textString = NSAttributedString(string: text, attributes: [.font: self.font, .foregroundColor: self.textColor, .baselineOffset: baseline])
+            let textString = NSAttributedString(string: text, attributes: [.font: self.font, .foregroundColor: self.textColor])
             mutableAttributedString.append(textString)
         }
         self.attributedText = mutableAttributedString

--- a/PinterestSegment/PinterestSegment.swift
+++ b/PinterestSegment/PinterestSegment.swift
@@ -438,8 +438,6 @@ extension UILabel {
             }
             
             attachment.bounds = CGRect(x: 0, y: (self.font.capHeight - size.height) / 2, width: image.size.width, height: image.size.height)
-            //baseline = size.height/4
-            //attachment.bounds = CGRect(x: 0, y: 0, width: size.width, height: size.height)
             let attachmentStr = NSAttributedString(attachment: attachment)
             mutableAttributedString.append(attachmentStr)
         }


### PR DESCRIPTION
This is a small fix to the method that adds the image decorator. Without this there are occasional issues with image / text vertical alignment. This fixes those issues